### PR TITLE
fix: restore quorum() override location

### DIFF
--- a/packages/core/solidity/src/governor.ts
+++ b/packages/core/solidity/src/governor.ts
@@ -113,7 +113,7 @@ function addBase(c: ContractBuilder, { name }: GovernorOptions) {
   c.addParent(Governor, [name]);
   c.addOverride(Governor, functions.votingDelay);
   c.addOverride(Governor, functions.votingPeriod);
-  c.addOverride(Governor, functions.quorum);
+  //c.addOverride(Governor, functions.quorum);
   c.addOverride(Governor, functions.state);
   c.addOverride(Governor, functions.propose);
   c.addOverride(Governor, functions.proposalNeedsQueuing);
@@ -308,6 +308,7 @@ function addQuorum(c: ContractBuilder, opts: Required<GovernorOptions>) {
         : `return ${opts.quorumAbsolute}e${opts.decimals};`;
 
     c.setFunctionBody([returnStatement], functions.quorum, 'pure');
+    c.addOverride({ name: 'Governor' }, functions.quorum);
   }
 }
 


### PR DESCRIPTION
This PR fixes a previous incorrect removal of the `Governor` override in the `quorum()` function.

The `Governor` override is now correctly placed under the `addQuorum()` block (instead of `addBase()`),  
ensuring proper behavior when `quorumMode === "absolute"`.

Ref: [PR #522](https://github.com/OpenZeppelin/contracts-wizard/pull/522)

Tested with Remix and local build — all compiles and behaves as expected.
